### PR TITLE
Install git-lfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "com.github.actions.description"="Automatically rebases PR on '/rebase' co
 LABEL "com.github.actions.icon"="git-pull-request"
 LABEL "com.github.actions.color"="purple"
 
-RUN apk --no-cache add jq bash curl git
+RUN apk --no-cache add jq bash curl git git-lfs
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Gives support for repositories with Git-LFS files on Actions 2.0

`This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout`