### PR TITLE
Trigger action only on issue-comment:created event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To configure the action simply add the following lines to your `.github/workflow
 
 ```yml
 on: issue_comment
+types: [created]
 name: Automatic Rebase
 jobs:
   rebase:

--- a/README.md
+++ b/README.md
@@ -11,18 +11,17 @@ After installation simply comment `/rebase` to trigger the action:
 To configure the action simply add the following lines to your `.github/workflows/rebase.yml` workflow file:
 
 ```yml
-on:
-  issue_comment:
-    types: [created]
-  name: Automatic Rebase
-  jobs:
-    rebase:
-      name: Rebase
-      runs-on: ubuntu-latest
-      steps:
-      - uses: actions/checkout@master
-      - name: Automatic Rebase
-        uses: cirrus-actions/rebase@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+on: issue_comment:
+  types: [created]
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Automatic Rebase
+      uses: cirrus-actions/rebase@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To configure the action simply add the following lines to your `.github/workflow
 ```yml
 on: 
   issue_comment:
-  types: [created]
+    types: [created]
 name: Automatic Rebase
 jobs:
   rebase:

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ To configure the action simply add the following lines to your `.github/workflow
 on:
   issue_comment:
     types: [created]
-    name: Automatic Rebase
-    jobs:
-      rebase:
-        name: Rebase
-        runs-on: ubuntu-latest
-        steps:
-        - uses: actions/checkout@master
-        - name: Automatic Rebase
-          uses: cirrus-actions/rebase@master
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  name: Automatic Rebase
+  jobs:
+    rebase:
+      name: Rebase
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@master
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ After installation simply comment `/rebase` to trigger the action:
 To configure the action simply add the following lines to your `.github/workflows/rebase.yml` workflow file:
 
 ```yml
-on: issue_comment:
+on: 
+  issue_comment:
   types: [created]
 name: Automatic Rebase
 jobs:

--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@ After installation simply comment `/rebase` to trigger the action:
 To configure the action simply add the following lines to your `.github/workflows/rebase.yml` workflow file:
 
 ```yml
-on: issue_comment
-types: [created]
-name: Automatic Rebase
-jobs:
-  rebase:
-    name: Rebase
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Automatic Rebase
-      uses: cirrus-actions/rebase@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+on:
+  issue_comment:
+    types: [created]
+    name: Automatic Rebase
+    jobs:
+      rebase:
+        name: Rebase
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@master
+        - name: Automatic Rebase
+          uses: cirrus-actions/rebase@master
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
Per https://help.github.com/en/articles/events-that-trigger-workflows#webhook-events this should save github action minutes (budget) because the action will only be started for „created issue comments“.

At the moment the actions are triggered on all issue comment events but then exit in entrypoint.sh

https://github.com/cirrus-actions/rebase/blob/4d7ad1db3ccc4e1e47d549847998041b22dc8aff/entrypoint.sh#L17-L20

This changes is not tested. Feedback welcome