### PR TITLE
Support rebasing PR from forks and allow only selected users to rebase

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,11 +69,14 @@ HEAD_BRANCH=$(echo "$pr_resp" | jq -r .head.ref)
 
 echo "Base branch for PR #$PR_NUMBER is $BASE_BRANCH"
 
-git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+USER_TOKEN=${USER_LOGIN}_TOKEN
+COMMITTER_TOKEN=${!USER_TOKEN:-$GITHUB_TOKEN}
+
+git remote set-url origin https://x-access-token:$COMMITTER_TOKEN@github.com/$GITHUB_REPOSITORY.git
 git config --global user.email "$USER_EMAIL"
 git config --global user.name "$USER_NAME"
 
-git remote add fork https://x-access-token:$GITHUB_TOKEN@github.com/$HEAD_REPO.git
+git remote add fork https://x-access-token:$COMMITTER_TOKEN@github.com/$HEAD_REPO.git
 
 set -o xtrace
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,24 +53,21 @@ HEAD_BRANCH=$(echo "$pr_resp" | jq -r .head.ref)
 
 echo "Base branch for PR #$PR_NUMBER is $BASE_BRANCH"
 
-if [[ "$BASE_REPO" != "$HEAD_REPO" ]]; then
-	echo "PRs from forks are not supported at the moment."
-	exit 1
-fi
-
 git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"
+
+git remote add fork https://x-access-token:$GITHUB_TOKEN@github.com/$HEAD_REPO.git
 
 set -o xtrace
 
 # make sure branches are up-to-date
 git fetch origin $BASE_BRANCH
-git fetch origin $HEAD_BRANCH
+git fetch fork $HEAD_BRANCH
 
 # do the rebase
-git checkout -b $HEAD_BRANCH origin/$HEAD_BRANCH
+git checkout -b $HEAD_BRANCH fork/$HEAD_BRANCH
 git rebase origin/$BASE_BRANCH
 
 # push back
-git push --force-with-lease
+git push --force-with-lease fork $HEAD_BRANCH


### PR DESCRIPTION
### Support rebasing PR from forks

This works only if the "Allow edit from maintainers" option is checked
and the `GITHUB_TOKEN` variable is set using a developer token, i.e.

```yml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
```

Fixes #12 

### Use the user name and email for committer name

Instead of using a generic name and address, fetch these information
from using the GitHub API.


### Allow user based tokens

If an environment variable `<user_login>_TOKEN` exists, that variable is
used instead of `GITHUB_TOKEN`.

This makes it possible to allow only some users to rebase the PRs by
setting

```yml
  env:
    <user1>_TOKEN: ${{ secrets.<user1>_TOKEN }}
    <user2>_TOKEN: ${{ secrets.<user2>_TOKEN }}
```