### PR TITLE
Fix job condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
-    if: contains(github.event.comment.body, '/rebase')
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -26,4 +26,11 @@ jobs:
       uses: cirrus-actions/rebase@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38186#M3250
+  always_job:
+    name: Aways run job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Always run
+        run: echo "This job is used to prevent the workflow to fail when all other jobs are skipped."
 ```


### PR DESCRIPTION
* Only run job on PR comment  
   This prevent rebase job from running on issue comment.
* Prevent workflow to fail when condition isn't met    
    If a comment isn't on a PR or doesn't match /rebase, the workflow would
    fail because no jobs meets the running condition.
    The given advice was to always have a no-op job running to prevent this.
