### PR TITLE
Use the correct version tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@v1.2
+      uses: cirrus-actions/rebase@1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38186#M3250


### PR DESCRIPTION
Remove the extra `v` in `uses: cirrus-actions/rebase@v1.2` in the README file