### PR TITLE
Remove legacy checks inside entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,23 +2,6 @@
 
 set -e
 
-# Workaround unitl new Actions support neutral strategy
-# See how it was before: https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses
-NEUTRAL_EXIT_CODE=0
-
-# skip if no /rebase
-echo "Checking if comment contains '/rebase' command..."
-(jq -r ".comment.body" "$GITHUB_EVENT_PATH" | grep -Fq "/rebase") || exit $NEUTRAL_EXIT_CODE
-
-# skip if not a PR
-echo "Checking if issue is a pull request..."
-(jq -r ".issue.pull_request.url" "$GITHUB_EVENT_PATH") || exit $NEUTRAL_EXIT_CODE
-
-if [[ "$(jq -r ".action" "$GITHUB_EVENT_PATH")" != "created" ]]; then
-	echo "This is not a new comment event!"
-	exit $NEUTRAL_EXIT_CODE
-fi
-
 PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
 echo "Collecting information about PR #$PR_NUMBER of $GITHUB_REPOSITORY..."
 


### PR DESCRIPTION
There is no need for then in the era of the new actions since it's possible to control when an action is triggered via YAML config and particularly `if` statement.

Fixes #34