### PR TITLE
Update Installation example to use newer Checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout the latest code
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Automatic Rebase


### PR DESCRIPTION
It seems that installation example in README uses old version of Checkout. 
v2 is currently the latest one: https://github.com/actions/checkout
Since most people just copy the provided example there might be quite a lot people using outdated version of Checkout. This PR should help address the issue for new users.