### PR TITLE
Support triggering by usernames that contain a hyphen

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ HEAD_BRANCH=$(echo "$pr_resp" | jq -r .head.ref)
 
 echo "Base branch for PR #$PR_NUMBER is $BASE_BRANCH"
 
-USER_TOKEN=${USER_LOGIN}_TOKEN
+USER_TOKEN=${USER_LOGIN//-/_}_TOKEN
 COMMITTER_TOKEN=${!USER_TOKEN:-$GITHUB_TOKEN}
 
 git remote set-url origin https://x-access-token:$COMMITTER_TOKEN@github.com/$GITHUB_REPOSITORY.git


### PR DESCRIPTION
Previously, if the trigger comment was made by a user with a hyphen in their user name, the script errors.

For example, if the user name was "foo-bar":
```
/entrypoint.sh: line 57: foo-bar_TOKEN: invalid variable name
```
Bash does not permit hyphens in variable names, but GitHub does permit hyphens in user names.

The fix is to do a character replacement of any hyphens in the user name before using it as a component of the variable name.

This will require that the workflow maintainer also make this character replacement when configuring user-specific access tokens (https://github.com/cirrus-actions/rebase/pull/17) in the workflow for users with hyphens in their user name. Since there is no documentation of the user-specific token feature of this action, I was not able to update it to note this requirement.