### PR TITLE
Add support for pull_request webhook events

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
+PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
 echo "Collecting information about PR #$PR_NUMBER of $GITHUB_REPOSITORY..."
 
 if [[ -z "$GITHUB_TOKEN" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,13 @@
 set -e
 
 PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
+if [[ "$PR_NUMBER" == "null" ]]; then
+	PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
+fi
+if [[ PR_NUMBER == "null" ]]; then
+	echo "Failed to determine PR Number."
+	exit 1
+fi
 echo "Collecting information about PR #$PR_NUMBER of $GITHUB_REPOSITORY..."
 
 if [[ -z "$GITHUB_TOKEN" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
 if [[ "$PR_NUMBER" == "null" ]]; then
 	PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
 fi
-if [[ PR_NUMBER == "null" ]]; then
+if [[ "$PR_NUMBER" == "null" ]]; then
 	echo "Failed to determine PR Number."
 	exit 1
 fi


### PR DESCRIPTION
Get the PR number from the `.pull_request.number` event prop when applicable, falling back to the `.issue.number`.

This allows use of other event webhooks (in my use-case, when a `pull_request` is `labeled`), e.g.

```
on:
  pull_request:
    types:
      - labeled
name: Automatic Rebase
jobs:
  rebase:
    if: github.event.label.name == 'rebase'
    name: Rebase
    runs-on: ubuntu-latest
    steps:
      - name: Checkout the latest code
        uses: actions/checkout@v2
        with:
          fetch-depth: 0
      - name: Automatic Rebase
        uses: cirrus-actions/rebase@1.3.1
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```