### PR TITLE
Allow PR_NUMBER to be set externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Example
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 ```
 
+You can also optionally specify the PR number of the branch to rebase,
+if the action you're running doesn't directly refer to a specific
+pull request:
+
+```yaml
+    - name: Automatic Rebase
+      uses: cirrus-actions/rebase@1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        PR_NUMBER: 1245
+```
 
 
 ## Restricting who can call the action

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,14 +2,17 @@
 
 set -e
 
-PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
-if [[ "$PR_NUMBER" == "null" ]]; then
-	PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
+if [ -z "$PR_NUMBER" ]; then
+	PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
+	if [[ "$PR_NUMBER" == "null" ]]; then
+		PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
+	fi
+	if [[ "$PR_NUMBER" == "null" ]]; then
+		echo "Failed to determine PR Number."
+		exit 1
+	fi
 fi
-if [[ "$PR_NUMBER" == "null" ]]; then
-	echo "Failed to determine PR Number."
-	exit 1
-fi
+
 echo "Collecting information about PR #$PR_NUMBER of $GITHUB_REPOSITORY..."
 
 if [[ -z "$GITHUB_TOKEN" ]]; then


### PR DESCRIPTION
I've put together an action that rebases a number of PRs in one go, and we would find it useful to be able to specify the `PR_NUMBER` externally. I've also added some initial documentation.