### PR TITLE
Fix failure if base and head branches have the same name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,8 +92,8 @@ git fetch origin $BASE_BRANCH
 git fetch fork $HEAD_BRANCH
 
 # do the rebase
-git checkout -b $HEAD_BRANCH fork/$HEAD_BRANCH
+git checkout -b fork/$HEAD_BRANCH fork/$HEAD_BRANCH
 git rebase origin/$BASE_BRANCH
 
 # push back
-git push --force-with-lease fork $HEAD_BRANCH
+git push --force-with-lease fork fork/$HEAD_BRANCH:$HEAD_BRANCH


### PR DESCRIPTION
This change prevents the failure of the rebase action when the base and head branches have the same name (e.g. when the head is a fork using the main/master branch).

Fixes #58 