### PR TITLE
Bump `@1.4` to `@1.5` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.4
+        uses: cirrus-actions/rebase@1.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -45,7 +45,7 @@ Example
         token: ${{ secrets.PAT_TOKEN }}
         fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.4
+      uses: cirrus-actions/rebase@1.5
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 ```
@@ -56,7 +56,7 @@ pull request:
 
 ```yaml
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.4
+      uses: cirrus-actions/rebase@1.5
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         PR_NUMBER: 1245


### PR DESCRIPTION
Was trying to get `env: PR_NUMBER: xxx` to work via copying the code in the README and ran into the `Failed to determine PR Number.` error.

Took me a while to realize that y'all fixed it in `cirrus-actions/rebase@1.5`! Just bumping the sample code up a version so that it just works upon copy/paste 😄 

Thanks for making this! ❤️