### PR TITLE
fix: added safe.directory /github/workspace global

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,7 @@ COMMITTER_TOKEN="$(echo -e "${UNTRIMMED_COMMITTER_TOKEN}" | tr -d '[:space:]')"
 git remote set-url origin https://x-access-token:$COMMITTER_TOKEN@github.com/$GITHUB_REPOSITORY.git
 git config --global user.email "$USER_EMAIL"
 git config --global user.name "$USER_NAME"
+git config --global --add safe.directory /github/workspace
 
 git remote add fork https://x-access-token:$COMMITTER_TOKEN@github.com/$HEAD_REPO.git
 


### PR DESCRIPTION
We're getting the following error using `cirrus-actions/rebase`:

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

    git config --global --add safe.directory /github/workspace
```

Some more context on this: https://github.com/actions/checkout/issues/766