### PR TITLE
fix(chore): bugs autosquash always set true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   autosquash:
     description: Should the rebase autosquash fixup and squash commits
     required: false
-    default: false
+    default: 'false'
 branding:
   icon: git-pull-request
   color: purple

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,7 +100,7 @@ git fetch fork $HEAD_BRANCH
 
 # do the rebase
 git checkout -b fork/$HEAD_BRANCH fork/$HEAD_BRANCH
-if [[ $INPUT_AUTOSQUASH -eq 'true' ]]; then
+if [[ $INPUT_AUTOSQUASH == 'true' ]]; then
 	GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash origin/$BASE_BRANCH
 else
 	git rebase origin/$BASE_BRANCH


### PR DESCRIPTION
Rebase autosquash condition on `entrypoint.sh` always read as true condition when set to false on input,
cause operator `-eq` only works for integer comparisons